### PR TITLE
Fixed bug that caused boss rooms to not work sometimes

### DIFF
--- a/Assets/Scripts/Dungeon/BossRoom.cs
+++ b/Assets/Scripts/Dungeon/BossRoom.cs
@@ -6,9 +6,9 @@ public class BossRoom : ChildRoom
 {
     public BossEnemySpawner bossEnemySpawner;
 
-    protected override void SpawnEnemies(ChildRoom room, Vector2 roomPos)
+    protected override void SpawnEnemies()
     {
-        GameManager.instance.SpawnEnemy(GameManager.instance.dungeonManager.settings.bossObject, roomPos);
-        Instantiate(bossEnemySpawner.gameObject, roomPos, Quaternion.identity).GetComponent<BossEnemySpawner>().BossStats = FindObjectOfType<FinalBoss>();
+        GameManager.instance.SpawnEnemy(GameManager.instance.dungeonManager.settings.bossObject, transform.position);
+        Instantiate(bossEnemySpawner.gameObject, transform.position, Quaternion.identity).GetComponent<BossEnemySpawner>().BossStats = FindObjectOfType<FinalBoss>();
     }
 }

--- a/Assets/Scripts/Dungeon/ChildRoom.cs
+++ b/Assets/Scripts/Dungeon/ChildRoom.cs
@@ -108,17 +108,17 @@ public class ChildRoom : MonoBehaviour
                 }
 
                 room.enemiesSpawned = true;
-                SpawnEnemies(room, roomPos);
+                room.SpawnEnemies();
             }
         }
     }
 
-    protected virtual void SpawnEnemies(ChildRoom room, Vector2 roomPos)
+    protected virtual void SpawnEnemies()
     {
-        foreach (GameObject enemy in room.enemySpawns)
+        foreach (GameObject enemy in enemySpawns)
         {
-            int spawnPoint = UnityEngine.Random.Range(0, room.spawnPoints.Length);
-            Vector2 enemyPos = new Vector2(roomPos.x + room.spawnPoints[spawnPoint].x, roomPos.y + room.spawnPoints[spawnPoint].y);
+            int spawnPoint = UnityEngine.Random.Range(0, spawnPoints.Length);
+            Vector2 enemyPos = new Vector2(transform.position.x + spawnPoints[spawnPoint].x, transform.position.y + spawnPoints[spawnPoint].y);
             GameManager.instance.SpawnEnemy(enemy, enemyPos);
         }
     }


### PR DESCRIPTION
The spawn enemies function now handles spawning enemies specifically only for the one room the function is on. This allows the boss room script to work when it has chained rooms attached to it.
